### PR TITLE
add github token from env and fix buildbot url

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -91,7 +91,7 @@ from buildbot.plugins import reporters, util
 from buildbot.process.properties import Interpolate
 
 context = Interpolate("buildbot/%(prop:buildername)s")
-gs = reporters.GitHubStatusPush(token='0dd09ee68216dceed5408926d65a5834a4322e93',
+gs = reporters.GitHubStatusPush(token=os.environ.get("BUILDBOT_STATUS_TOKEN"),
                                 context=context,
                                 startDescription='Build started.',
                                 endDescription='Build done.',
@@ -177,7 +177,7 @@ c['titleURL'] = "https://wiki.gentoo.org/wiki/Project:Kernel"
 # the 'www' entry below, but with an externally-visible host name which the
 # buildbot cannot figure out without some help.
 
-c['buildbotURL'] = "http://localhost:8010/"
+c['buildbotURL'] = "http://kernel1.amd64.dev.gentoo.org:8010/"
 
 # minimalistic config to activate new web UI
 c['www'] = dict(port=8010,


### PR DESCRIPTION
Getting Github token from BUILDBOT_STATUS_TOKEN os enviroment variable
fixing buildbot url link