### PR TITLE
add stabilization factory example

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -154,7 +154,7 @@ gs = reporters.GitHubStatusPush(token=os.environ.get("BUILDBOT_STATUS_TOKEN"),
 
 def download_new_patch_and_build_kernel(version):
     factory = util.BuildFactory()
-    factory.addStep(steps.GitHub(repourl='https://github.com/aliceinwire/linux-patches',
+    factory.addStep(steps.GitHub(repourl='https://github.com/gentoo/linux-patches',
                           mode='incremental',workdir="build/linux-patches", branch=version))
     factory.addStep(steps.FileDownload(mastersrc="~/files/check-kernelpage.py",
                                    workerdest="files/check-kernelpage.py"))
@@ -181,14 +181,22 @@ def download_new_patch_and_build_kernel(version):
     return factory
 
 
-def test_gentoo_sources(version):
+@util.renderer
+def filterFiles(props):
+    files = props.getBuild().allFiles()
+    build_files = [s for s in files if "sys-kernel/gentoo-sources" in s]
+    command = ["/usr/bin/python", "stabilize-packages.py"]
+    for file in build_files:
+        command.append(file)
+    print(str(command))
+    return command
+
+def test_gentoo_sources():
     factory = util.BuildFactory()
-    factory.addStep(steps.ShellCommand(command=["emerge", "--sync"]))
-    factory.addStep(steps.ShellCommand(command=["emerge", "-v", '=gentoo-sources-' + version ]))
-    factory.addStep(steps.ShellCommand(command=["make", "allyesconfig"],
-                                       workdir="/usr/src/linux-" + version + "-gentoo"))
-    factory.addStep(steps.ShellCommand(command=["make"],
-                                       workdir="/usr/src/linux-" + version + "-gentoo"))
+    factory.addStep(steps.FileDownload(mastersrc="~/files/stabilize-packages.py",
+                                       workerdest="files/stabilize-packages.py"))
+    factory.addStep(steps.ShellCommand(command=filterFiles,
+                                       workdir="build/files/"))
     return factory
 
 
@@ -204,7 +212,7 @@ for build_name, kernel_version in download_new_patch_and_build_kernel_kernel_lis
 c['builders'].append(
     util.BuilderConfig(name='gentoo_sources',
       workernames=["kernelci"],
-      factory=test_gentoo_sources("4.9.8")))
+      factory=test_gentoo_sources()))
 
 ####### BUILDBOT SERVICES
 


### PR DESCRIPTION
fixed kernel check factory git checkout url to gentoo/linux-patches

function filterFiles get the changed files under
sys-kernel/gentoo-sources and is adding it to the python script as
argument.