### PR TITLE
changed password for checking travis buildbot fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - mkdir buildbot
   - cd buildbot
   - buildbot create-master master
-  - echo 'test:test' > master/password
+  - printf 'test:test\ntest2:test' > master/password
   - printf 'kernelci:test\nkernelci2:test' > master/workers.cfg
   - rm -f master/master.cfg.sample
   - cp ../master.cfg master/.

--- a/files/qemu_check.py
+++ b/files/qemu_check.py
@@ -40,8 +40,13 @@ ult-20170521.qcow2 -O '+ vmimage , stdout=subprocess.PIPE, shell=True)
 else:
     print("vmimage present: " + vmimage)
 
+if isinstance(vmlinuz_list, str):
+    vmlinuz_list = [vmlinuz_list]
+
 for vmlinuz in vmlinuz_list:
-    work = command('qemu-system-x86_64 -m 128M -kernel /boot/vmlinuz-'+ vmlinuz +' -nographic -serial mon:stdio -hda '+ vmimage +' -append "root=/dev/sda1 console=ttyS0,115200n8 console=tty0"', 60)
+    print(vmlinuz)
+    work = command('qemu-system-x86_64 -m 128M -kernel /boot/vmlinuz-'+ vmlinuz +' -nographic -serial mon:stdio -hda '+ vmimage +' -append "root=/dev/sda1 console=ttyS0,115200n8 console=tty0"', 120)
+    time.sleep(600)
     if work:
         print("worked")
     else:


### PR DESCRIPTION
The command "cd master" exited with 0.
1.58s$ buildbot checkconfig master.cfg
error while parsing config file:
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/twisted/internet/defer.py", line 150, in maybeDeferred
    result = f(*args, **kw)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/buildbot/scripts/checkconfig.py", line 60, in checkconfig
    return _loadConfig(basedir=basedir, configFile=configFile, quiet=quiet)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/buildbot/scripts/checkconfig.py", line 30, in _loadConfig
    config.FileLoader(basedir, configFile).loadConfig()
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/buildbot/config.py", line 179, in loadConfig
    self.basedir, self.configFileName)
--- <exception caught here> ---
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/buildbot/config.py", line 137, in loadConfigDict
    execfile(filename, localDict)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/twisted/python/compat.py", line 261, in execfile
    exec(code, globals, locals)
  File "/home/travis/build/gentoo/Gentoo_kernelCI/buildbot/master/master.cfg", line 305, in <module>
    c['www']['auth'] = util.UserPasswordAuth(usernames_passwords)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/buildbot/www/auth.py", line 174, in __init__
    for user, password in users.items():
exceptions.AttributeError: 'list' object has no attribute 'items'
Configuration Errors:
  error while parsing config file: 'list' object has no attribute 'items' (traceback in logfile)
The command "buildbot checkconfig master.cfg" exited with 1.