### PR TITLE
check-kernelpage.py: Add compatibility for python2

### DIFF
--- a/files/check-kernelpage.py
+++ b/files/check-kernelpage.py
@@ -10,11 +10,24 @@ import tarfile
 
 if sys.version_info.major == 3:
     from urllib.request import urlretrieve
+    import lzma
+
+    def extract(filename):
+        with tarfile.open(filename) as tar:
+            tar.extractall()
+
 else:
     from urllib import urlretrieve
+    from backports import lzma
+
+    def extract(filename):
+        with lzma.open(filename) as f, open(filename[:-3], 'wb') as fout:
+            file_content = f.read()
+            fout.write(file_content)
+        with tarfile.open(filename[:-3]) as tar:
+            tar.extractall()
 
 from configparser import ConfigParser
-import lzma
 import os
 from os import walk
 import re
@@ -109,13 +122,11 @@ if os.path.exists(kernel_tarxz):
     if os.path.exists("linux-" + new_version):
         pass
     else:
-        with tarfile.open(kernel_tarxz) as tar:
-            tar.extractall()
+        extract(kernel_tarxz)
 else:
     urlretrieve("http://distfiles.gentoo.org/distfiles/" +
-                               kernel_tarxz, kernel_tarxz)
-    with tarfile.open(kernel_tarxz) as tar:
-        tar.extractall()
+                kernel_tarxz, kernel_tarxz)
+    extract(kernel_tarxz)
 
 print("new_version_split"+str(new_version_split))
 len_new_version_split = len(new_version_split)

--- a/files/check-kernelpage.py
+++ b/files/check-kernelpage.py
@@ -7,7 +7,11 @@ import shutil
 import subprocess
 import sys
 import tarfile
-import urllib
+
+if sys.version_info.major == 3:
+    from urllib.request import urlretrieve
+else:
+    from urllib import urlretrieve
 
 from configparser import ConfigParser
 import lzma
@@ -108,7 +112,7 @@ if os.path.exists(kernel_tarxz):
         with tarfile.open(kernel_tarxz) as tar:
             tar.extractall()
 else:
-    urllib.request.urlretrieve("http://distfiles.gentoo.org/distfiles/" +
+    urlretrieve("http://distfiles.gentoo.org/distfiles/" +
                                kernel_tarxz, kernel_tarxz)
     with tarfile.open(kernel_tarxz) as tar:
         tar.extractall()
@@ -134,7 +138,7 @@ if int(revision) > 1:
     patch_url = "http://cdn.kernel.org/pub/linux/kernel/v4.x/incr/" +\
                 incremental_patch_name
     print(patch_url)
-    urllib.request.urlretrieve(patch_url, incremental_patch_name)
+    urlretrieve(patch_url, incremental_patch_name)
     with lzma.open(incremental_patch_name) as f, open(
             incremental_patch_name[:-3], 'wb') as fout:
         file_content = f.read()
@@ -144,7 +148,7 @@ else:
     print("revision: " + str(revision))
     patch_url = "http://cdn.kernel.org/pub/linux/kernel/v4.x/" + patch_name
     print(patch_url)
-    urllib.request.urlretrieve(patch_url, patch_name)
+    urlretrieve(patch_url, patch_name)
     with lzma.open(patch_name) as f, open(patch_name[:-3], 'wb') as fout:
         file_content = f.read()
         fout.write(file_content)


### PR DESCRIPTION
Currently, most of the scripts are running correctly with both python3 and python2, except this one. This is due to incompatibility issues on the urlllib, tarfile and lzma.