### PR TITLE
Monitor branch 4.16 for kernel builders

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -120,7 +120,7 @@ def eclass_change(change):
 
 c['schedulers'] = []
 
-for branch in ['4.15', '4.14', '4.13', '4.12', '4.11', '4.10', '4.9',
+for branch in ['4.16', '4.15', '4.14', '4.13', '4.12', '4.11', '4.10', '4.9',
                '4.8', '4.4', '4.1']:
     c['schedulers'].append(schedulers.SingleBranchScheduler(
                                 name=branch,
@@ -295,7 +295,7 @@ def test_gentoo_sources():
     return factory
 
 
-download_new_patch_and_build_kernel_kernel_list = {'4.15':'4.15','4.14':'4.14',
+download_new_patch_and_build_kernel_kernel_list = {'4.16':'4.16', '4.15':'4.15','4.14':'4.14',
                                                    '4.13':'4.13','4.12':'4.12',
                                                    '4.11':'4.11','4.10':'4.10',
                                                    '4.9':'4.9','4.8':'4.8',


### PR DESCRIPTION
This adds branch 4.16 for testing kernel builds and boot. This is based onto my branch for ARM. So you should first merge the PR for ARM (#53 ), then merge this one.

Regards,
Romain