### PR TITLE
Add smtp email informations

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -21,6 +21,13 @@ def load_password():
 
 usernames_passwords, admin_usernames = load_password()
 
+def load_mail_password():
+    """ read worker information from workers file """
+    with open('mail_password', 'r') as f:
+        mail_password = f.readline()
+    return mail_password
+
+mail_password = load_mail_password()
 
 def load_worker():
     """ read worker information from workers file """
@@ -381,7 +388,10 @@ mn = reporters.MailNotifier(fromaddr="kernelCI-buildbot@gentoo.org",
                                              'm.j.everitt@iee.org'],
                             messageFormatter=reporters.MessageFormatter(
                                template=template, template_type='html',
-                               wantProperties=True, wantSteps=True))
+                               wantProperties=True, wantSteps=True),
+                               useTls=True, relayhost="smtp.gmail.com",
+                               smtpPort=587, smtpUser="gkernelci@gmail.com",
+                               smtpPassword=mail_password)
 
 c['services'].append(mn)
 c['services'].append(gs)


### PR DESCRIPTION
The password is hidden in the mail_password file.
This is just a simple hack and need better code.

Signed-off-by: Alice Ferrazzi <alicef@gentoo.org>