### PR TITLE
Make kernel version into a list, to prevent expansion after 'shelve'ing

### DIFF
--- a/files/check-kernelpage.py
+++ b/files/check-kernelpage.py
@@ -109,7 +109,7 @@ for i in tr_table:
         break
 conf_var = "shelve"
 d = shelve.open(conf_var)
-d["version"] = new_version_revision
+d["version"] = [new_version_revision]
 d.close()
 print(new_version_revision)
 new_version_split = new_version_revision.split('.', 2)


### PR DESCRIPTION
Kernel version is a simple string, but gets 'exploded' in scripts that follow,
leading to some completely unviable commands trying to be run!

Signed-off-by: M. J. Everitt <m.j.everitt@iee.org>