### PR TITLE
 Improve qemu test image handling

### DIFF
--- a/files/clean.sh
+++ b/files/clean.sh
@@ -3,3 +3,4 @@ python3 clean.py
 rm -rf files/
 rm -rf gentoo/
 rm -rf linux-patches/
+find /tmp -name "gentoo*.qcow2" -mtime +2 -delete

--- a/files/clean.sh
+++ b/files/clean.sh
@@ -3,4 +3,4 @@ python3 clean.py
 rm -rf files/
 rm -rf gentoo/
 rm -rf linux-patches/
-find /tmp -name "gentoo*.qcow2" -mtime +2 -delete
+find /tmp -maxdepth 1 -name "gentoo*.qcow2" -mtime +2 -size -100M -delete

--- a/files/qemu_check.py
+++ b/files/qemu_check.py
@@ -7,12 +7,12 @@ import shelve
 import sys
 
 if len(sys.argv) < 4:
-    print("Usage: qemu_check.py [<arch>] <worker#> <build#>")
+    print("Usage: qemu_check.py <arch> <builder> <build#>")
     sys.exit(1)
 #arch = "amd64" if len(sys.argv) < 4 else sys.argv[1]
 arch   = sys.argv[1]
-worker = sys.argv[2]
-build  = sys.argv[3]
+builder = sys.argv[2]
+build_id  = sys.argv[3]
 
 conf_var = "shelve"
 d = shelve.open(conf_var)
@@ -20,10 +20,13 @@ vmlinuz_list = d["version"]
 d.close()
 
 qemu_timeout = 360
-BaseURIamd64 = 'http://gentoo.osuosl.org/experimental/amd64/openstack/'\
-          'gentoo-openstack-amd64-default-'
-BaseURIarm = ''
 SnapshotDate = 'latest'
+BaseURIamd64 = 'http://gentoo.osuosl.org/experimental/amd64/openstack/'
+amd64img = 'gentoo-openstack-amd64-default-' + SnapshotDate + '.qcow2'
+BaseURIarm32 = ''
+arm32img = ''
+BaseURIarm64 = ''
+arm64img = ''
 
 
 def command(cmd, timeout_sec):
@@ -34,9 +37,8 @@ def command(cmd, timeout_sec):
     try:
         timer.start()
         for line in proc.stdout:
-            a = line.strip()
-            print(a)
-            if 'This is localhost' in str(a):
+            print(line.strip())
+            if 'This is localhost' in str(line.strip()):
                 work = True
                 break
     finally:
@@ -44,43 +46,51 @@ def command(cmd, timeout_sec):
     proc.kill()
     return work
 
+# Set up some variables depending on arch
 if arch == 'amd64':
-    vmimage = "/tmp/gentoo-amd64-w" + worker + ".qcow2"
-    # + "-b" + build
+    ImageURI = BaseURIamd64 + amd64img
+    vmimage_src = amd64img
+    vmimage_dest = "gentoo-amd64-" + builder + "-b" + build_id + ".qcow2"
     cmd_qemu = 'qemu-system-x86_64 -m 128M -kernel ' \
         'linux-amd64-build/arch/x86/boot/bzImage' \
-        ' -nographic -serial mon:stdio -hda ' + vmimage + \
+        ' -nographic -serial mon:stdio -hda /tmp/' + vmimage_dest + \
         ' -append "root=/dev/sda1 console=ttyS0,115200n8 console=tty0"'
 elif arch == 'arm':
-    vmimage = "/tmp/gentoo-arm-w" + worker + ".qcow2"
-    # + "-b" + build + ".qcow2"
+    ImageURI = BaseURIarm + arm32img
+    vmimage_src = arm32img
+    vmimage_dest = "gentoo-arm-" + builder + "-b" + build_id + ".qcow2"
     cmd_qemu = 'qemu-system-arm -M vexpress-a9 -smp 2 -m 1G -kernel ' \
         'linux-arm-build/arch/arm/boot/zImage' \
         ' -dtb linux-arm-build/arch/arm/boot/dts/vexpress-v2p-ca9.dtb' \
-        ' -sd ' + vmimage + ' -nographic -append "console=ttyAMA0,115200' \
+        ' -sd /tmp/' + vmimage_dest + ' -nographic -append "console=ttyAMA0,115200' \
         ' root=/dev/mmcblk0 rootwait"'
 
-if not os.path.isfile(vmimage):
-    if arch == 'amd64':
-        ImageURI = BaseURIamd64 + SnapshotDate + '.qcow2'
-    elif arch == 'arm':
-        ImageURI = BaseURIarm + SnapshotDate + '.qcow2'
-    cmd_wget = 'wget -N ' + ImageURI + ' -O ' + vmimage
+# Check for existing base image, download if needed
+if not os.path.isfile(vmimage_src):
+    cmd_wget = 'wget -Nc ' + ImageURI + ' -P /tmp'
     proc2 = subprocess.Popen(cmd_wget, stdout=subprocess.PIPE, shell=True)
     for line in proc2.stdout:
-        a = line.strip()
-        print(a)
-    if not os.path.isfile(vmimage):
+        print(line.strip())
+    if not os.path.isfile(vmimage_src):
         print("Cannot download file: " + ImageURI)
         sys.exit(1)
 else:
-    print("vmimage present: " + vmimage)
+    print("vmimage present: " + vmimage_src)
 
+# Create snapshot of base image for build
+cmd_clone_qemu_img = 'qemu-img create -f qcow2 -b ' + vmimage_src + ' ' + \
+                     vmimage_dest
+proc2 = subprocess.Popen(cmd_clone_qemu_img, stdout=subprocess.PIPE, shell=True)
+for line in proc2.stdout:
+    print(line.strip())
+
+# Print [imported] list of kernels to build
 print(vmlinuz_list)
 
 if isinstance(vmlinuz_list, str):
     vmlinuz_list = [vmlinuz_list]
 
+# Build the kernels...
 for vmlinuz in vmlinuz_list:
     print(vmlinuz)
     work = command(cmd_qemu, qemu_timeout)

--- a/files/qemu_check.py
+++ b/files/qemu_check.py
@@ -71,20 +71,20 @@ elif arch == 'arm':
         ' root=/dev/mmcblk0 rootwait"'
 
 # Check for existing base image, download if needed
-if not os.path.isfile(vmimage_src):
+if not os.path.isfile('/tmp/' + vmimage_src):
     cmd_wget = 'wget -Nc ' + ImageURI + ' -P /tmp'
     proc2 = subprocess.Popen(cmd_wget, stdout=subprocess.PIPE, shell=True)
     for line in proc2.stdout:
         print(line.strip())
-    if not os.path.isfile(vmimage_src):
+    if not os.path.isfile('/tmp/' + vmimage_src):
         print("Cannot download file: " + ImageURI)
         sys.exit(1)
 else:
     print("vmimage present: " + vmimage_src)
 
 # Create snapshot of base image for build
-cmd_clone_qemu_img = 'qemu-img create -f qcow2 -b ' + vmimage_src + ' ' + \
-                     vmimage_dest
+cmd_clone_qemu_img = 'qemu-img create -f qcow2 -b /tmp/' + vmimage_src + ' ' + \
+                     '/tmp/' + vmimage_dest
 proc2 = subprocess.Popen(cmd_clone_qemu_img, stdout=subprocess.PIPE, shell=True)
 for line in proc2.stdout:
     print(line.strip())

--- a/files/qemu_check.py
+++ b/files/qemu_check.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import subprocess
 import sys
-from threading import Timer
 import os.path
 import shelve
-import sys
+import subprocess
+from threading import Timer
 
 if len(sys.argv) < 4:
     print("Usage: qemu_check.py <arch> <builder> <build#>")
@@ -45,7 +44,7 @@ def command(cmd, timeout_sec):
             print(line.strip())
             if 'This is localhost' in str(line.strip()):
                 work = True
-                break
+                # break
     finally:
         timer.cancel()
     proc.kill()
@@ -67,8 +66,8 @@ elif arch == 'arm':
     cmd_qemu = 'qemu-system-arm -M vexpress-a9 -smp 2 -m 1G -kernel ' \
         'linux-arm-build/arch/arm/boot/zImage' \
         ' -dtb linux-arm-build/arch/arm/boot/dts/vexpress-v2p-ca9.dtb' \
-        ' -sd /tmp/' + vmimage_dest + ' -nographic -append "console=ttyAMA0,115200' \
-        ' root=/dev/mmcblk0 rootwait"'
+        ' -sd /tmp/' + vmimage_dest + ' -nographic -append ' \
+        '"console=ttyAMA0,115200 root=/dev/mmcblk0 rootwait"'
 
 # Check for existing base image, download if needed
 if not os.path.isfile('/tmp/' + vmimage_src):
@@ -83,9 +82,10 @@ else:
     print("vmimage present: " + vmimage_src)
 
 # Create snapshot of base image for build
-cmd_clone_qemu_img = 'qemu-img create -f qcow2 -b /tmp/' + vmimage_src + ' ' + \
-                     '/tmp/' + vmimage_dest
-proc2 = subprocess.Popen(cmd_clone_qemu_img, stdout=subprocess.PIPE, shell=True)
+cmd_clone_qemu_img = 'qemu-img create -f qcow2 -b /tmp/' + vmimage_src + \
+                     ' /tmp/' + vmimage_dest
+proc2 = subprocess.Popen(cmd_clone_qemu_img, stdout=subprocess.PIPE,
+                         shell=True)
 for line in proc2.stdout:
     print(line.strip())
 

--- a/files/qemu_check.py
+++ b/files/qemu_check.py
@@ -9,10 +9,15 @@ import sys
 if len(sys.argv) < 4:
     print("Usage: qemu_check.py <arch> <builder> <build#>")
     sys.exit(1)
-#arch = "amd64" if len(sys.argv) < 4 else sys.argv[1]
-arch   = sys.argv[1]
-builder = sys.argv[2]
-build_id  = sys.argv[3]
+# arch = "amd64" if len(sys.argv) < 4 else sys.argv[1]
+
+arch = sys.argv[1]
+build_id = sys.argv[3]
+if (arch in sys.argv[2]):
+    builder = sys.argv[2].split(':')[0]
+else:
+    builder = sys.argv[2]
+
 
 conf_var = "shelve"
 d = shelve.open(conf_var)

--- a/master.cfg
+++ b/master.cfg
@@ -281,7 +281,7 @@ def download_new_patch_and_build_kernel(version, arch):
 
     factory.addStep(steps.ShellCommand(name="Booting with QEMU",
                                        command=["/usr/bin/python", "qemu_check.py", arch,
-                                                util.Property('workername'), util.Property('buildnumber')],
+                                                util.Property('buildername'), util.Property('buildnumber')],
                                        workdir="build/files/", timeout=3600))
 
     factory.addStep(steps.ShellCommand(name="Cleanup",


### PR DESCRIPTION
This seems to be a fairly robust answer to the issue of multiple builds wanting to concurrently access the qemu test image for boot testing.

I think the only thing missing from this PR is cleanup of the resulting snapshots/'clones' but as these should be Copy-on-Write, they should actually be small in size anyway.

Deployed, tested & running successfully on 'vmz-ci-test'.