### PR TITLE
Add 4.20 kernel branch, remove old/unused

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -128,8 +128,8 @@ def eclass_change(change):
 c['schedulers'] = []
 
 architecture_testing_list = ['amd64', 'arm']
-branches_list = ['4.19', '4.18', '4.17', '4.16', '4.15', '4.14', '4.13',
-                 '4.12', '4.11', '4.10', '4.9', '4.8', '4.4', '4.1']
+branches_list = ['4.20', '4.19', '4.18', '4.14',
+                 '4.9', '4.8', '4.4', '4.1']
 
 def builderNames(branch):
     builders = set()


### PR DESCRIPTION
I have removed some of the older kernel branches as I'm not sure there is any merit in keeping configs for them, if there are genuinely no updates likely.

However, if there is some reason to keep them around, happy to revert this particular prune!