### PR TITLE
Use defcofing instead of oldconfig

### DIFF
--- a/files/patch-kernel.sh
+++ b/files/patch-kernel.sh
@@ -75,7 +75,7 @@ if [ ! -z "${kernel_version}" ]; then
 			make ARCH=${kernel_arch_target} O=${kernel_builddir} defconfig
 		fi
 		make mrproper
-		yes "" | make ARCH=${kernel_arch_target} O=${kernel_builddir} oldconfig
+		yes "" | make ARCH=${kernel_arch_target} O=${kernel_builddir} defconfig
 	else
 		echo "Using ~/kernel-config/config-${version}"
 		cp ~/kernel-config/config-"${version}" .config


### PR DESCRIPTION
Because we are trying to build with different
architecture using oldconfig and reusing .config
is sometime not going to work.