### PR TITLE
Set limit on concurrent jobs on worker to 4

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -53,7 +53,7 @@ c = BuildmasterConfig = {}
 
 c['workers'] = []
 for name, password in workers_info:
-    c['workers'].append(worker.Worker(name, password))
+    c['workers'].append(worker.Worker(name, password, max_builds=4))
 
 # 'protocols' contains information about protocols which master will use for
 # communicating with workers. You must define at least 'port' option that workers


### PR DESCRIPTION
Following on from #88 .

Signed-off-by: M. J. Everitt <m.j.everitt@iee.org>