### PR TITLE
Fix 'make oldconfig' so that existing config isn't wiped

### DIFF
--- a/files/patch-kernel.sh
+++ b/files/patch-kernel.sh
@@ -78,8 +78,8 @@ if [ ! -z "${kernel_version}" ]; then
 		yes "" | make ARCH=${kernel_arch_target} O=${kernel_builddir} defconfig
 	else
 		echo "Using ~/kernel-config/config-${version}"
-		cp ~/kernel-config/config-"${version}" .config
 		make mrproper
+		cp ~/kernel-config/config-"${version}" .config
 		yes "" | make ARCH=${kernel_arch_target} O=${kernel_builddir} oldconfig
 	fi
 fi


### PR DESCRIPTION
Not 100% sure on this, but pretty sure mrproper or distclean will
clean .config. Re-order 'make mrproper' and the copy command
so that mrproper cannot wipe copied config!

Signed-off-by: M. J. Everitt <m.j.everitt@iee.org>