### PR TITLE
Remove experimental patches from patch list

### DIFF
--- a/files/check-kernelpage.py
+++ b/files/check-kernelpage.py
@@ -188,6 +188,8 @@ else:
         shutil.move(patch_name[:-3], '../linux-patches/' + patch_name[:-3] +
                     '.patch')
 
+os.chdir(mypath)
+
 base = []
 extra = []
 experimental = []
@@ -197,7 +199,8 @@ for i in filenames:
     if re.match(r'^[34]', i):
         extra.append(i)
     if re.match(r'^50', i):
-        experimental.append(i)
+        #experimental.append(i)
+        os.unlink(i)
 # remove 0000_README file from the list
 base.pop(1)
 print("base patch")


### PR DESCRIPTION
Presently, there is some logic in ebuilds which selectively
applies patches depending on some environment parameters.
Until we have a mechanism in kernelCI to replicate this,
disable applying experimental patches for now.
Experimental patches may/may not be fully supported, but
these can be monitored separately from the main genpatches
set for the time being.
At some stage in the future, when we have finer-grained
application of patches in the CI system, these can probably
be added back in to the mix.

Signed-off-by: M. J. Everitt <m.j.everitt@iee.org>